### PR TITLE
Username Display Control

### DIFF
--- a/sendCustomMessage.js
+++ b/sendCustomMessage.js
@@ -1,4 +1,5 @@
 const { web, rtm } = require('./server/slackClient')
+const { getSelf } = require('./server/self')
 const args = require('args-parser')(process.argv)
 
 console.info(args)
@@ -8,10 +9,12 @@ const go = async () => {
   await web.chat.postMessage({
     text: args.m,
     channel: args.c,
-    as_user: args.a,
+    as_user: false,
     username: args.u
   })
   process.exit(0)
 }
 
 go()
+const self = getSelf()
+console.log(self.id)

--- a/sendCustomMessage.js
+++ b/sendCustomMessage.js
@@ -7,7 +7,9 @@ const go = async () => {
   await rtm.start()
   await web.chat.postMessage({
     text: args.m,
-    channel: args.c
+    channel: args.c,
+    as_user: args.a,
+    username: args.u
   })
   process.exit(0)
 }

--- a/server/handleMessage.js
+++ b/server/handleMessage.js
@@ -109,7 +109,9 @@ module.exports = async (event) => {
     ) {
       await web.chat.postMessage({
         text: event.text,
-        channel: event.channel
+        channel: event.channel,
+        as_user: false,
+        // username: // getSelf().id ??
       })
     }
 
@@ -135,27 +137,35 @@ module.exports = async (event) => {
       let options = [
         'no worries',
         'any time',
-        'you\'re welcome!'
+        'you\'re welcome!',
+        'sure thing my dude',
+        'yeah!'
       ]
       let text = options[Math.floor(Math.random() * options.length)]
       await delay(1000)
       await web.chat.postMessage({
         text: text,
-        channel: event.channel
+        channel: event.channel,
+        as_user: false,
+        // username: // how can we determine jeremy's username, rather than his bot name?
       })
     }
 
-    if (event.text === 'respond_jerm') {
+    if (event.text === 'respond_jerm' | 
+        event.text === 'jeremy me boy') {
       let options = [
         'hey',
         'hello',
-        'hi there!'
+        'hi there!',
+        'hey daddy'
       ]
       let text = options[Math.floor(Math.random() * options.length)]
       await delay(1000)
       await web.chat.postMessage({
         text: text,
-        channel: event.channel
+        channel: event.channel,
+        as_user: false,
+        // username: getSelf().id doesn't work? or does it?
       })
     }
 


### PR DESCRIPTION
@nickells @giomrella don't merge this yet - I could use some help/review. 
Also, let me know if I should base on a different branch besides master. 
Should we set up an integration branch?

Specifically, I'm trying to figure out how to read Jeremy's display name at any time, and then make sure that's forced as the username/display name that Jeremy responds as. What I have so far is merely a skeleton that will let us set Jeremy's username according to how we want - I don't know how to read his _current_ username to plug in there.

You'd think this would be automatic, but it's not! For example, you can set in the `web.chat.postMessage()` method a `username` argument (only active if `as_user = false`) that can take any value. You can also change Jeremy's icon and url on the fly as well! 
